### PR TITLE
feat(security): automate container remediation PRs

### DIFF
--- a/.github/container-security-images.json
+++ b/.github/container-security-images.json
@@ -1,0 +1,12 @@
+{
+  "images": {
+    "amir20/dozzle": {
+      "tag_regex": "^v(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)$",
+      "version_scheme": "semver"
+    },
+    "owasp/modsecurity-crs": {
+      "tag_regex": "^4-nginx-alpine-(?P<version>[0-9]{12})$",
+      "version_scheme": "numeric"
+    }
+  }
+}

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,9 +8,9 @@ container security automation.
 
 | Workflow | Trigger | Purpose |
 | --- | --- | --- |
-| [`ci.yml`](ci.yml) | Pushes and pull requests targeting `main` | Validates Compose and shell scripts, runs application checks, scans pinned third-party images, tests the candidate runtime and Daily Brief WAF exclusions, and publishes first-party images on a push. |
+| [`ci.yml`](ci.yml) | Pushes and pull requests targeting `main`, or manual dispatch | Validates Compose and shell scripts, runs application checks, tests the container remediation helper, scans pinned third-party images, tests the candidate runtime and Daily Brief WAF exclusions, and publishes first-party images on a push. |
 | [`cd.yml`](cd.yml) | Successful `CI` completion on `main` | Deploys the exact successful commit to production, validates the deployment, and cleans up old images. |
-| [`container-security.yml`](container-security.yml) | Daily at 03:45 Asia/Singapore, or manually | Rescans pinned NGINX/ModSecurity and Dozzle images, manages the actionable-vulnerability issue, and verifies production image references. |
+| [`container-security.yml`](container-security.yml) | Daily at 03:45 Asia/Singapore, or manually | Rescans pinned NGINX/ModSecurity and Dozzle images, tests newer remediation candidates, creates or updates a security upgrade PR when a candidate passes, manages the actionable-vulnerability issue, and verifies production image references. |
 | [`content-sync.yml`](content-sync.yml) | Manual or external `workflow_dispatch` | Pulls the current `main` branch on production, synchronizes article content, and runs health and smoke checks. |
 | [`infra-sync.yml`](infra-sync.yml) | Sundays at 11:00 Asia/Singapore, or manually | Validates, plans, and applies the Terraform configuration for GCP. |
 
@@ -26,15 +26,28 @@ merge/push to main -> CI checks and image publication -> CD -> production valida
 Third-party image maintenance follows this sequence:
 
 ```text
-Dependabot PR -> CI scan and candidate runtime checks -> review and merge -> CD
-daily container scan -> GitHub issue on actionable HIGH/CRITICAL findings
+normal Dependabot PR -> CI scan and candidate runtime checks -> review and merge -> CD
+daily container scan -> actionable HIGH/CRITICAL finding -> scan newer image tags
+clean candidate -> security remediation PR -> explicitly dispatched CI -> review and merge -> CD
+no clean candidate -> keep the GitHub security issue open -> retry on the next scan
 ```
 
-When the daily scan finds an actionable vulnerability, the scan job fails
-intentionally after creating or updating the security issue. Its error
-annotation and job summary explicitly distinguish this policy failure from a
-runner failure, list the findings, and explain the Dependabot-driven upgrade
-path.
+When the daily scan finds an actionable vulnerability, it looks up newer tags
+using [`../../scripts/security/container_remediation.py`](../../scripts/security/container_remediation.py)
+and the image policies in
+[`../container-security-images.json`](../container-security-images.json). It
+tries candidates from newest to oldest and accepts only an immutable digest
+whose Trivy scan contains no fixable HIGH/CRITICAL findings. The workflow then
+creates or refreshes the bot-owned
+`container-security/remediate-pinned-images` branch and opens one reviewed
+security PR for the accepted image changes. Normal Dependabot updates retain
+their cooldown because this path runs only after the pinned image fails the
+security policy.
+
+The scan job still fails intentionally after creating or updating the security
+issue and remediation PR. Its annotation and summary distinguish the policy
+failure from a runner failure and explain whether a clean candidate or PR was
+available.
 
 Production deployment, content synchronization, and the production-reference
 check share the `production-deploy` concurrency group. They wait for each other
@@ -56,8 +69,17 @@ Terraform additionally requires:
 - `GCP_TERRAFORM_SERVICE_ACCOUNT`
 
 First-party container publication uses the automatically provided
-`GITHUB_TOKEN`. The daily security workflow uses the same token to manage a
-single open security issue.
+`GITHUB_TOKEN`. The daily security workflow uses a job-scoped token with
+`contents`, `issues`, `pull-requests`, and `actions` write permissions to manage
+one security issue, its bot-owned remediation branch and PR, and the explicit
+CI dispatch for that branch. Other jobs retain read-only repository access.
+
+Repository administrators must enable **Settings > Actions > General > Allow
+GitHub Actions to create and approve pull requests**. If it is disabled, the
+workflow keeps the security issue open and reports that a clean candidate was
+found, but deliberately does not leave an orphan remediation branch. Pull
+requests created with `GITHUB_TOKEN` do not recursively trigger workflows, so
+the security job explicitly dispatches `ci.yml` against the remediation branch.
 
 ## Failure and maintenance notes
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main # 仅 main 分支 push 触发
@@ -60,6 +61,9 @@ jobs:
         with:
           inputs: web-app/requirements.txt
           no-deps: true
+
+      - name: Test container security remediation helper
+        run: python3 -m unittest discover -s scripts/security/tests -p 'test_*.py' -v
 
       - name: Run pytest with coverage gate
         run: >

--- a/.github/workflows/container-security.yml
+++ b/.github/workflows/container-security.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 concurrency:
   group: container-security
@@ -18,6 +17,11 @@ jobs:
   scan-pinned-images:
     name: Scan pinned images (security policy gate)
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -50,14 +54,21 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p trivy-reports
-          trivy image --scanners vuln --format json \
-            --ignorefile .trivyignore.yaml \
-            --skip-version-check \
-            --output trivy-reports/nginx.json "${NGINX_IMAGE}"
-          trivy image --scanners vuln --format json \
-            --ignorefile .trivyignore.yaml \
-            --skip-version-check \
-            --output trivy-reports/dozzle.json "${DOZZLE_IMAGE}"
+          scan_image() {
+            local name="$1"
+            local image="$2"
+            local temporary_report="trivy-reports/${name}.raw.json"
+            trivy image --scanners vuln --format json \
+              --ignorefile .trivyignore.yaml \
+              --skip-version-check \
+              --output "${temporary_report}" "${image}"
+            jq --arg image "${image}" '. + {ScannedImage: $image}' \
+              "${temporary_report}" > "trivy-reports/${name}.json"
+            rm "${temporary_report}"
+          }
+
+          scan_image nginx "${NGINX_IMAGE}"
+          scan_image dozzle "${DOZZLE_IMAGE}"
 
       - name: Build actionable vulnerability report
         id: findings
@@ -66,6 +77,7 @@ jobs:
           jq -s '
             [
               .[]
+              | .ScannedImage as $image
               | .Results[]?
               | .Target as $target
               | .Vulnerabilities[]?
@@ -74,6 +86,7 @@ jobs:
                   and ((.FixedVersion // "") != "")
                 )
               | {
+                  image: $image,
                   target: $target,
                   id: .VulnerabilityID,
                   severity: .Severity,
@@ -82,7 +95,7 @@ jobs:
                   fixed: .FixedVersion
                 }
             ]
-            | unique_by([.target, .id, .package])
+            | unique_by([.image, .target, .id, .package])
           ' trivy-reports/*.json > trivy-reports/actionable.json
 
           count="$(jq 'length' trivy-reports/actionable.json)"
@@ -91,9 +104,9 @@ jobs:
           {
             echo "The daily scan found **${count}** fixed HIGH/CRITICAL vulnerabilities in the pinned production images."
             echo
-            echo "| Severity | CVE | Package | Installed | Fixed | Target |"
-            echo "| --- | --- | --- | --- | --- | --- |"
-            jq -r '.[:50][] | "| \(.severity) | `\(.id)` | `\(.package)` | `\(.installed)` | `\(.fixed)` | `\(.target)` |"' \
+            echo "| Severity | CVE | Package | Installed | Fixed | Image | Target |"
+            echo "| --- | --- | --- | --- | --- | --- | --- |"
+            jq -r '.[:50][] | "| \(.severity) | `\(.id)` | `\(.package)` | `\(.installed)` | `\(.fixed)` | `\(.image)` | `\(.target)` |"' \
               trivy-reports/actionable.json
             echo
             echo "Workflow: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
@@ -103,7 +116,192 @@ jobs:
             fi
           } > trivy-reports/issue.md
 
+      - name: Discover and scan remediation candidates
+        id: remediation
+        if: steps.findings.outputs.count != '0'
+        env:
+          TRIVY_NO_PROGRESS: "true"
+        run: |
+          set -euo pipefail
+          mkdir -p trivy-reports/candidates
+          echo '[]' > trivy-reports/remediations.json
+
+          while IFS= read -r current_image; do
+            candidates_file="trivy-reports/candidates/discovered.json"
+            if ! python3 scripts/security/container_remediation.py discover \
+              --config .github/container-security-images.json \
+              --image "${current_image}" \
+              --max-candidates 10 > "${candidates_file}"; then
+              echo "::warning title=Container remediation discovery failed::Unable to discover candidates for ${current_image}. The vulnerability issue will remain open."
+              continue
+            fi
+
+            selected_candidate=""
+            selected_released_at=""
+            candidate_index=0
+            while IFS= read -r candidate_record; do
+              candidate_index=$((candidate_index + 1))
+              candidate_image="$(jq -r '.image' <<< "${candidate_record}")"
+              candidate_report="trivy-reports/candidates/candidate-${candidate_index}.json"
+              echo "Scanning remediation candidate ${candidate_image}"
+              if ! trivy image --scanners vuln --format json \
+                --ignorefile .trivyignore.yaml \
+                --skip-version-check \
+                --output "${candidate_report}" "${candidate_image}"; then
+                echo "::warning title=Container candidate scan failed::Unable to scan ${candidate_image}; trying the next candidate."
+                continue
+              fi
+
+              candidate_findings="$(
+                jq '[
+                  .Results[]?
+                  | .Vulnerabilities[]?
+                  | select(
+                      (.Severity == "HIGH" or .Severity == "CRITICAL")
+                      and ((.FixedVersion // "") != "")
+                    )
+                ] | length' "${candidate_report}"
+              )"
+              if (( candidate_findings == 0 )); then
+                selected_candidate="${candidate_image}"
+                selected_released_at="$(jq -r '.released_at' <<< "${candidate_record}")"
+                break
+              fi
+              echo "Candidate ${candidate_image} still has ${candidate_findings} actionable HIGH/CRITICAL findings."
+            done < <(jq -c '.[]' "${candidates_file}")
+
+            if [[ -z "${selected_candidate}" ]]; then
+              echo "::notice title=No clean container candidate::No newer candidate for ${current_image} passed the repository security policy."
+              continue
+            fi
+
+            python3 scripts/security/container_remediation.py replace \
+              --file compose.yml \
+              --current "${current_image}" \
+              --candidate "${selected_candidate}"
+            jq \
+              --arg current "${current_image}" \
+              --arg candidate "${selected_candidate}" \
+              --arg released_at "${selected_released_at}" \
+              '. + [{current: $current, candidate: $candidate, released_at: $released_at}]' \
+              trivy-reports/remediations.json > trivy-reports/remediations.tmp.json
+            mv trivy-reports/remediations.tmp.json trivy-reports/remediations.json
+          done < <(jq -r 'map(.image) | unique[]' trivy-reports/actionable.json)
+
+          remediation_count="$(jq 'length' trivy-reports/remediations.json)"
+          echo "count=${remediation_count}" >> "${GITHUB_OUTPUT}"
+
+      - name: Create or update container security pull request
+        id: remediation_pr
+        if: steps.remediation.outcome == 'success' && steps.remediation.outputs.count != '0'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REMEDIATION_BRANCH: container-security/remediate-pinned-images
+        run: |
+          set -euo pipefail
+
+          actions_can_create_prs="$(
+            gh api "repos/${GITHUB_REPOSITORY}/actions/permissions/workflow" \
+              --jq '.can_approve_pull_request_reviews'
+          )"
+          if [[ "${actions_can_create_prs}" != "true" ]]; then
+            echo "::error title=Automatic remediation PR is disabled::Enable Settings > Actions > General > Allow GitHub Actions to create and approve pull requests. Candidate images passed the security scan, but no PR was created."
+            exit 1
+          fi
+
+          {
+            echo "This PR was created automatically because the pinned production image contains a fixable HIGH/CRITICAL vulnerability."
+            echo
+            echo "Normal Dependabot version updates keep their cooldown. This security remediation path only runs after the current pinned image fails the repository's container security policy."
+            echo
+            echo "| Current image | Security-cleared candidate | Candidate published |"
+            echo "| --- | --- | --- |"
+            jq -r '.[] | "| `\(.current)` | `\(.candidate)` | \(.released_at) |"' \
+              trivy-reports/remediations.json
+            echo
+            echo "The candidate images were scanned with the same Trivy HIGH/CRITICAL and fix-available policy used by CI. Versions remain pinned to immutable Docker Hub digests and still require review plus the full CI runtime checks."
+            echo
+            echo "Source security scan: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          } > trivy-reports/remediation-pr.md
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -C "${REMEDIATION_BRANCH}"
+          git add compose.yml
+          candidate_tree="$(git write-tree)"
+          pushed=false
+
+          remote_sha="$(git ls-remote --heads origin "refs/heads/${REMEDIATION_BRANCH}" | awk '{print $1}')"
+          if [[ -n "${remote_sha}" ]]; then
+            git fetch origin "refs/heads/${REMEDIATION_BRANCH}:refs/remotes/origin/${REMEDIATION_BRANCH}"
+            remote_tree="$(git rev-parse "refs/remotes/origin/${REMEDIATION_BRANCH}^{tree}")"
+          else
+            remote_tree=""
+          fi
+
+          if [[ "${candidate_tree}" != "${remote_tree}" ]]; then
+            git commit -m "fix(security): upgrade vulnerable container images"
+            if [[ -n "${remote_sha}" ]]; then
+              git push \
+                --force-with-lease="refs/heads/${REMEDIATION_BRANCH}:${remote_sha}" \
+                origin "HEAD:refs/heads/${REMEDIATION_BRANCH}"
+            else
+              git push origin "HEAD:refs/heads/${REMEDIATION_BRANCH}"
+            fi
+            pushed=true
+          fi
+
+          pr_url="$(
+            gh pr list --repo "${GITHUB_REPOSITORY}" --state open \
+              --head "${REMEDIATION_BRANCH}" --json url --jq '.[0].url // empty'
+          )"
+          created=false
+          if [[ -z "${pr_url}" ]]; then
+            gh label create security --repo "${GITHUB_REPOSITORY}" \
+              --color B60205 --description "Security maintenance" --force
+            pr_url="$(
+              gh pr create --repo "${GITHUB_REPOSITORY}" \
+                --base main --head "${REMEDIATION_BRANCH}" \
+                --title "fix(security): upgrade vulnerable container images" \
+                --label security --body-file trivy-reports/remediation-pr.md
+            )"
+            created=true
+          else
+            gh pr edit "${pr_url}" --repo "${GITHUB_REPOSITORY}" \
+              --body-file trivy-reports/remediation-pr.md --add-label security
+          fi
+
+          echo "url=${pr_url}" >> "${GITHUB_OUTPUT}"
+          if [[ "${pushed}" == "true" || "${created}" == "true" ]]; then
+            gh workflow run ci.yml --repo "${GITHUB_REPOSITORY}" --ref "${REMEDIATION_BRANCH}"
+          fi
+
+      - name: Add remediation status to the security report
+        if: always() && steps.findings.outputs.count != '0'
+        env:
+          REMEDIATION_COUNT: ${{ steps.remediation.outputs.count }}
+          REMEDIATION_OUTCOME: ${{ steps.remediation.outcome }}
+          REMEDIATION_PR_OUTCOME: ${{ steps.remediation_pr.outcome }}
+          REMEDIATION_PR_URL: ${{ steps.remediation_pr.outputs.url }}
+        run: |
+          {
+            echo
+            echo "## Automated remediation"
+            echo
+            if [[ "${REMEDIATION_OUTCOME}" != "success" ]]; then
+              echo "Candidate discovery or scanning did not complete successfully. Check the remediation step logs; the scanner will retry on the next run."
+            elif [[ "${REMEDIATION_COUNT:-0}" == "0" ]]; then
+              echo "No newer image candidate passed the repository security policy. The scanner will try again on the next run."
+            elif [[ "${REMEDIATION_PR_OUTCOME}" == "success" ]]; then
+              echo "A newer candidate passed the security scan and the remediation PR is ready: ${REMEDIATION_PR_URL}"
+            else
+              echo "A newer candidate passed the security scan, but the remediation PR could not be created or updated. Check the remediation step annotation."
+            fi
+          } >> trivy-reports/issue.md
+
       - name: Create, update, or close the security issue
+        if: always() && steps.findings.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FINDING_COUNT: ${{ steps.findings.outputs.count }}
@@ -135,9 +333,13 @@ jobs:
           fi
 
       - name: Security update required (intentional policy failure)
-        if: steps.findings.outputs.count != '0'
+        if: always() && steps.findings.outputs.count != '0'
         env:
           FINDING_COUNT: ${{ steps.findings.outputs.count }}
+          REMEDIATION_COUNT: ${{ steps.remediation.outputs.count }}
+          REMEDIATION_OUTCOME: ${{ steps.remediation.outcome }}
+          REMEDIATION_PR_OUTCOME: ${{ steps.remediation_pr.outcome }}
+          REMEDIATION_PR_URL: ${{ steps.remediation_pr.outputs.url }}
         run: |
           set -euo pipefail
 
@@ -162,7 +364,15 @@ jobs:
             echo
             echo "### What to do next"
             echo
-            echo "1. Review and merge the Dependabot image upgrade pull request when it becomes available."
+            if [[ "${REMEDIATION_OUTCOME}" != "success" ]]; then
+              echo "1. Candidate discovery or scanning failed; review the remediation step logs. The next scheduled scan will retry."
+            elif [[ "${REMEDIATION_COUNT:-0}" != "0" && "${REMEDIATION_PR_OUTCOME}" == "success" ]]; then
+              echo "1. Review the automatically generated security upgrade PR: ${REMEDIATION_PR_URL}"
+            elif [[ "${REMEDIATION_COUNT:-0}" != "0" ]]; then
+              echo "1. A security-cleared candidate was found, but PR creation failed. Review the remediation step annotation."
+            else
+              echo "1. No security-cleared newer image is available yet; the next scheduled scan will try again."
+            fi
             echo "2. Confirm that CI and deployment complete successfully."
             echo "3. The next clean scheduled scan will close the security issue automatically."
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Host bootstrap 由 `infra/ansible/` 负责，主要用于现有 VM 的基础环�
 - ModSecurity audit log 以不含完整 request header/body 的 `AHZ` 记录进入容器日志，既能定位原始 rule ID，也避免发布 token 被整体写入 audit record；具体 rule message 仍可能包含必要的命中片段
 - `nginx-modsecurity` 默认开启 WAF
 - Nginx/ModSecurity 与 Dozzle 使用 stable tag + immutable digest；Dependabot 每日检查 Docker Compose 镜像更新并通过 PR 提交变化
-- `.github/workflows/container-security.yml` 每日重扫固定镜像；存在未豁免且已有修复的 HIGH/CRITICAL finding 时维护 GitHub security issue
+- `.github/workflows/container-security.yml` 每日重扫固定镜像；存在未豁免且已有修复的 HIGH/CRITICAL finding 时，会按镜像版本策略扫描较新的候选 tag，只有候选通过相同安全策略才以 immutable digest 创建或更新安全升级 PR，并继续维护 GitHub security issue 直到修复合并
 - `.trivyignore.yaml` 只接受带原因与到期日的临时风险例外，到期后扫描会重新阻断
 - 生产环境的 origin TLS 由 Nginx 挂载 Cloudflare Origin CA 证书；开发环境可使用自签名证书
 - Cloudflare 目前已对 `/static/*` 启用 edge cache；`/rendered-articles/*.html` 暂未纳入缓存计划

--- a/compose.yml
+++ b/compose.yml
@@ -106,7 +106,7 @@ services:
     logging: *default-logging
   # logs ui
   dozzle:
-    image: amir20/dozzle:v10.6.14@sha256:1c1060cfb5402093c4e0f03f3534d7deaffeb0a6f6dd034e7c5f244603f35fb3
+    image: amir20/dozzle:v10.7.1@sha256:a8441e9d2928cc7b30d0023f5eedbb87ef6e234d87f3be02662bd8f417955b8b
     container_name: dozzle
     environment:
       - DOZZLE_BASE=/web-log # set url path

--- a/scripts/security/README.md
+++ b/scripts/security/README.md
@@ -1,0 +1,42 @@
+# Container Security Remediation
+
+`container_remediation.py` is the repository helper used by the daily
+Container Security workflow to find newer Docker Hub images and replace one
+exact pinned `tag@digest` reference in `compose.yml`.
+
+The helper does not decide whether an update is safe. The workflow first scans
+the currently pinned images, calls this helper to discover newer stable tags,
+then scans each candidate with the same Trivy policy used by CI. A candidate is
+written to `compose.yml` only after that scan reports no fixable HIGH or
+CRITICAL vulnerabilities.
+
+Image-specific tag formats live in
+[`../../.github/container-security-images.json`](../../.github/container-security-images.json).
+Each regular expression must expose a named `version` group. The supported
+ordering strategies are semantic versions with exactly three numeric
+components and monotonically increasing numeric versions. This currently
+covers Dozzle semantic tags and the date-based NGINX/ModSecurity tags without
+hard-coding a vulnerability ID or fixed release.
+
+The discovery client intentionally supports Docker Hub only. Adding another
+registry requires an explicit discovery implementation so that the digest
+written to Compose remains the immutable manifest-list digest returned by that
+registry.
+
+## Commands
+
+```bash
+python3 scripts/security/container_remediation.py discover \
+  --config .github/container-security-images.json \
+  --image 'amir20/dozzle:v10.6.14@sha256:...'
+
+python3 scripts/security/container_remediation.py replace \
+  --file compose.yml \
+  --current 'amir20/dozzle:v10.6.14@sha256:...' \
+  --candidate 'amir20/dozzle:v10.7.1@sha256:...'
+
+python3 -m unittest discover -s scripts/security/tests -p 'test_*.py' -v
+```
+
+`replace` requires the complete current reference to occur exactly once and
+refuses to switch repositories.

--- a/scripts/security/container_remediation.py
+++ b/scripts/security/container_remediation.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Discover and pin safe container update candidates for security remediation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+DOCKER_HUB_API = "https://hub.docker.com/v2/repositories"
+DIGEST_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class RemediationError(RuntimeError):
+    """Raised when an image or remediation configuration is invalid."""
+
+
+@dataclass(frozen=True)
+class ImageReference:
+    repository: str
+    tag: str
+    digest: str | None
+
+    @property
+    def docker_hub_repository(self) -> str:
+        repository = self.repository
+        for prefix in ("docker.io/", "index.docker.io/"):
+            if repository.startswith(prefix):
+                repository = repository.removeprefix(prefix)
+                break
+        if "." in repository.split("/", 1)[0] or ":" in repository.split("/", 1)[0]:
+            raise RemediationError(
+                f"Only Docker Hub repositories are supported, got {self.repository!r}"
+            )
+        if "/" not in repository:
+            repository = f"library/{repository}"
+        return repository
+
+
+def parse_image_reference(value: str) -> ImageReference:
+    """Parse repository:tag@digest while preserving an unqualified repository."""
+    reference, separator, digest = value.partition("@")
+    if separator and not DIGEST_PATTERN.fullmatch(digest):
+        raise RemediationError(f"Invalid image digest in {value!r}")
+
+    last_slash = reference.rfind("/")
+    last_colon = reference.rfind(":")
+    if last_colon <= last_slash:
+        raise RemediationError(f"Image reference must include an explicit tag: {value!r}")
+
+    repository = reference[:last_colon]
+    tag = reference[last_colon + 1 :]
+    if not repository or not tag:
+        raise RemediationError(f"Invalid image reference: {value!r}")
+
+    return ImageReference(repository=repository, tag=tag, digest=digest or None)
+
+
+def load_policy(config_path: Path, repository: str) -> dict[str, str]:
+    try:
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise RemediationError(f"Unable to read {config_path}: {error}") from error
+
+    images = config.get("images")
+    if not isinstance(images, dict):
+        raise RemediationError(f"{config_path} must contain an 'images' object")
+
+    policy = images.get(repository)
+    if not isinstance(policy, dict):
+        raise RemediationError(f"No remediation policy configured for {repository!r}")
+
+    tag_regex = policy.get("tag_regex")
+    version_scheme = policy.get("version_scheme")
+    if not isinstance(tag_regex, str) or version_scheme not in {"semver", "numeric"}:
+        raise RemediationError(f"Invalid remediation policy for {repository!r}")
+    try:
+        expression = re.compile(tag_regex)
+    except re.error as error:
+        raise RemediationError(f"Invalid tag_regex for {repository!r}: {error}") from error
+    if "version" not in expression.groupindex:
+        raise RemediationError(
+            f"tag_regex for {repository!r} must define a named 'version' group"
+        )
+
+    return {"tag_regex": tag_regex, "version_scheme": version_scheme}
+
+
+def version_key(version: str, scheme: str) -> tuple[int, ...]:
+    if scheme == "semver":
+        parts = version.split(".")
+        if len(parts) != 3 or any(not part.isdigit() for part in parts):
+            raise RemediationError(f"Invalid semantic version {version!r}")
+        return tuple(int(part) for part in parts)
+    if scheme == "numeric" and version.isdigit():
+        return (int(version),)
+    raise RemediationError(f"Invalid numeric version {version!r}")
+
+
+def select_candidates(
+    image: ImageReference,
+    policy: dict[str, str],
+    tag_records: Iterable[dict[str, Any]],
+    max_candidates: int,
+) -> list[dict[str, str]]:
+    expression = re.compile(policy["tag_regex"])
+    scheme = policy["version_scheme"]
+    current_match = expression.fullmatch(image.tag)
+    if current_match is None:
+        raise RemediationError(
+            f"Current tag {image.tag!r} does not match the configured tag policy"
+        )
+    current_key = version_key(current_match.group("version"), scheme)
+
+    candidates: list[tuple[tuple[int, ...], dict[str, str]]] = []
+    seen_tags: set[str] = set()
+    for record in tag_records:
+        tag = record.get("name")
+        digest = record.get("digest")
+        if not isinstance(tag, str) or tag in seen_tags:
+            continue
+        match = expression.fullmatch(tag)
+        if match is None or not isinstance(digest, str) or not DIGEST_PATTERN.fullmatch(digest):
+            continue
+        candidate_key = version_key(match.group("version"), scheme)
+        if candidate_key <= current_key:
+            continue
+        seen_tags.add(tag)
+        candidates.append(
+            (
+                candidate_key,
+                {
+                    "repository": image.repository,
+                    "tag": tag,
+                    "digest": digest,
+                    "image": f"{image.repository}:{tag}@{digest}",
+                    "released_at": str(record.get("last_updated") or ""),
+                },
+            )
+        )
+
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    return [candidate for _, candidate in candidates[:max_candidates]]
+
+
+def fetch_docker_hub_tags(repository: str, max_pages: int = 10) -> list[dict[str, Any]]:
+    namespace, name = repository.split("/", 1)
+    url = (
+        f"{DOCKER_HUB_API}/{urllib.parse.quote(namespace, safe='')}/"
+        f"{urllib.parse.quote(name, safe='')}/tags?page_size=100&ordering=last_updated"
+    )
+    records: list[dict[str, Any]] = []
+    for _ in range(max_pages):
+        request = urllib.request.Request(url, headers={"User-Agent": "website-container-security/1"})
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                payload = json.load(response)
+        except (OSError, urllib.error.HTTPError, json.JSONDecodeError) as error:
+            raise RemediationError(f"Docker Hub tag lookup failed for {repository}: {error}") from error
+
+        page_records = payload.get("results")
+        if not isinstance(page_records, list):
+            raise RemediationError(f"Docker Hub returned an invalid tag list for {repository}")
+        records.extend(record for record in page_records if isinstance(record, dict))
+
+        next_url = payload.get("next")
+        if not isinstance(next_url, str) or not next_url:
+            break
+        url = next_url
+    return records
+
+
+def replace_image_reference(file_path: Path, current: str, candidate: str) -> None:
+    if parse_image_reference(current).repository != parse_image_reference(candidate).repository:
+        raise RemediationError("Current and candidate image repositories do not match")
+    try:
+        content = file_path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise RemediationError(f"Unable to read {file_path}: {error}") from error
+    occurrences = content.count(current)
+    if occurrences != 1:
+        raise RemediationError(
+            f"Expected exactly one occurrence of {current!r} in {file_path}, found {occurrences}"
+        )
+    file_path.write_text(content.replace(current, candidate, 1), encoding="utf-8")
+
+
+def discover_command(args: argparse.Namespace) -> None:
+    image = parse_image_reference(args.image)
+    docker_hub_repository = image.docker_hub_repository
+    policy = load_policy(args.config, docker_hub_repository)
+    records = fetch_docker_hub_tags(docker_hub_repository)
+    candidates = select_candidates(image, policy, records, args.max_candidates)
+    json.dump(candidates, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+def replace_command(args: argparse.Namespace) -> None:
+    replace_image_reference(args.file, args.current, args.candidate)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    discover = subparsers.add_parser("discover", help="list newer Docker Hub candidates")
+    discover.add_argument("--config", type=Path, required=True)
+    discover.add_argument("--image", required=True)
+    discover.add_argument("--max-candidates", type=int, default=10)
+    discover.set_defaults(handler=discover_command)
+
+    replace = subparsers.add_parser("replace", help="replace one pinned image reference")
+    replace.add_argument("--file", type=Path, required=True)
+    replace.add_argument("--current", required=True)
+    replace.add_argument("--candidate", required=True)
+    replace.set_defaults(handler=replace_command)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    if getattr(args, "max_candidates", 1) < 1:
+        parser.error("--max-candidates must be at least 1")
+    try:
+        args.handler(args)
+    except RemediationError as error:
+        print(f"container remediation error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/security/tests/test_container_remediation.py
+++ b/scripts/security/tests/test_container_remediation.py
@@ -1,0 +1,120 @@
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIRECTORY = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPT_DIRECTORY))
+
+from container_remediation import (  # noqa: E402
+    ImageReference,
+    RemediationError,
+    load_policy,
+    parse_image_reference,
+    replace_image_reference,
+    select_candidates,
+)
+
+
+class ContainerRemediationTests(unittest.TestCase):
+    def test_parse_pinned_reference(self):
+        reference = parse_image_reference(
+            "amir20/dozzle:v10.6.14@sha256:" + "a" * 64
+        )
+
+        self.assertEqual(reference.repository, "amir20/dozzle")
+        self.assertEqual(reference.tag, "v10.6.14")
+        self.assertEqual(reference.digest, "sha256:" + "a" * 64)
+        self.assertEqual(reference.docker_hub_repository, "amir20/dozzle")
+
+    def test_rejects_non_docker_hub_registry(self):
+        reference = parse_image_reference("ghcr.io/example/service:v1.0.0")
+
+        with self.assertRaises(RemediationError):
+            _ = reference.docker_hub_repository
+
+    def test_selects_only_newer_stable_tags_in_version_order(self):
+        image = ImageReference("amir20/dozzle", "v10.6.14", "sha256:" + "1" * 64)
+        policy = {
+            "tag_regex": r"^v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)$",
+            "version_scheme": "semver",
+        }
+        records = [
+            {"name": "v10.6.15", "digest": "sha256:" + "2" * 64},
+            {"name": "v10.7.1", "digest": "sha256:" + "3" * 64},
+            {"name": "v10.7.0-rc1", "digest": "sha256:" + "4" * 64},
+            {"name": "v10.6.13", "digest": "sha256:" + "5" * 64},
+            {"name": "latest", "digest": "sha256:" + "6" * 64},
+        ]
+
+        candidates = select_candidates(image, policy, records, max_candidates=10)
+
+        self.assertEqual([candidate["tag"] for candidate in candidates], ["v10.7.1", "v10.6.15"])
+        self.assertEqual(
+            candidates[0]["image"],
+            "amir20/dozzle:v10.7.1@sha256:" + "3" * 64,
+        )
+
+    def test_numeric_version_policy(self):
+        image = ImageReference(
+            "owasp/modsecurity-crs",
+            "4-nginx-alpine-202607160307",
+            None,
+        )
+        policy = {
+            "tag_regex": r"^4-nginx-alpine-(?P<version>[0-9]{12})$",
+            "version_scheme": "numeric",
+        }
+        records = [
+            {
+                "name": "4-nginx-alpine-202608050608",
+                "digest": "sha256:" + "7" * 64,
+            },
+            {
+                "name": "4-apache-202608050608",
+                "digest": "sha256:" + "8" * 64,
+            },
+        ]
+
+        candidates = select_candidates(image, policy, records, max_candidates=10)
+
+        self.assertEqual([candidate["tag"] for candidate in candidates], ["4-nginx-alpine-202608050608"])
+
+    def test_replace_requires_exactly_one_matching_reference(self):
+        current = "amir20/dozzle:v10.6.14@sha256:" + "1" * 64
+        candidate = "amir20/dozzle:v10.7.1@sha256:" + "2" * 64
+        with tempfile.TemporaryDirectory() as directory:
+            compose_file = Path(directory) / "compose.yml"
+            compose_file.write_text(f"services:\n  dozzle:\n    image: {current}\n", encoding="utf-8")
+
+            replace_image_reference(compose_file, current, candidate)
+
+            self.assertIn(candidate, compose_file.read_text(encoding="utf-8"))
+            with self.assertRaises(RemediationError):
+                replace_image_reference(compose_file, current, candidate)
+
+    def test_load_policy_requires_named_version_group(self):
+        with tempfile.TemporaryDirectory() as directory:
+            config_file = Path(directory) / "config.json"
+            config_file.write_text(
+                json.dumps(
+                    {
+                        "images": {
+                            "amir20/dozzle": {
+                                "tag_regex": "^v[0-9]+$",
+                                "version_scheme": "semver",
+                            }
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(RemediationError):
+                load_policy(config_file, "amir20/dozzle")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- extend the daily Container Security workflow to discover newer Docker Hub tags only after a pinned image has a fixable HIGH/CRITICAL finding
- scan candidates from newest to oldest with the same Trivy policy, pin a passing candidate by immutable digest, and create or refresh one reviewed remediation PR
- explicitly dispatch CI for bot-created PR commits while keeping normal Dependabot cooldown behavior unchanged
- add a policy-driven, tested Docker Hub discovery helper for Dozzle SemVer tags and ModSecurity date tags
- bootstrap the flow by upgrading Dozzle from v10.6.14 to the security-cleared v10.7.1 digest

## Verification

- `python3 -m unittest discover -s scripts/security/tests -p 'test_*.py' -v`
- `docker compose -f compose.yml config --quiet`
- `docker compose -f compose.yml -f compose.dev.yml config --quiet`
- `actionlint` against all workflows
- live Docker Hub discovery for both managed images
- Trivy v0.72.0: Dozzle v10.6.14 has 1 actionable finding; v10.7.1 has 0
- Dozzle v10.7.1 container healthcheck passed

## Rollout requirement

Before merging, enable **Settings > Actions > General > Allow GitHub Actions to create and approve pull requests**. The remediation job checks this setting before touching its bot-owned branch and otherwise leaves the security issue open with a clear annotation.
