### PR TITLE
chore(deps): update indirect Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
       - "python"
     commit-message:
       prefix: "deps(pip)"
+    allow:
+      - dependency-type: "all"
     ignore:
       - dependency-name: "pytest"
         update-types:


### PR DESCRIPTION
## Summary

- allow Dependabot pip version updates to include indirect dependencies
- keep the existing weekly schedule and minor/patch grouping

## Verification

- parsed `.github/dependabot.yml` with PyYAML
- `git diff --check`