### PR TITLE
fix(ci): gate only changed container images

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,8 +8,8 @@ container security automation.
 
 | Workflow | Trigger | Purpose |
 | --- | --- | --- |
-| [`ci.yml`](ci.yml) | Pushes and pull requests targeting `main`, or manual dispatch | Validates Compose and shell scripts, runs application checks, tests the container remediation helper, scans pinned third-party images, tests the candidate runtime and Daily Brief WAF exclusions, and publishes first-party images on a push. |
-| [`cd.yml`](cd.yml) | Successful `CI` completion on `main` | Deploys the exact successful commit to production, validates the deployment, and cleans up old images. |
+| [`ci.yml`](ci.yml) | Pushes and pull requests targeting `main`, or manual dispatch | Validates Compose and shell scripts, runs application checks, scans changed pinned third-party images, tests the complete candidate runtime and Daily Brief WAF exclusions independently of that scan, and publishes first-party images after all required push checks pass. |
+| [`cd.yml`](cd.yml) | Successful push-triggered `CI` completion on `main` | Deploys the exact successful commit to production, validates the deployment, and cleans up old images. Manual CI dispatches never trigger deployment. |
 | [`container-security.yml`](container-security.yml) | Daily at 03:45 Asia/Singapore, or manually | Rescans pinned NGINX/ModSecurity and Dozzle images, tests newer remediation candidates, creates or updates a security upgrade PR when a candidate passes, manages the actionable-vulnerability issue, and verifies production image references. |
 | [`content-sync.yml`](content-sync.yml) | Manual or external `workflow_dispatch` | Pulls the current `main` branch on production, synchronizes article content, and runs health and smoke checks. |
 | [`infra-sync.yml`](infra-sync.yml) | Sundays at 11:00 Asia/Singapore, or manually | Validates, plans, and applies the Terraform configuration for GCP. |
@@ -31,6 +31,23 @@ daily container scan -> actionable HIGH/CRITICAL finding -> scan newer image tag
 clean candidate -> security remediation PR -> explicitly dispatched CI -> review and merge -> CD
 no clean candidate -> keep the GitHub security issue open -> retry on the next scan
 ```
+
+The required CI container gate is revision-aware. For pull requests it compares
+the merge candidate with the pull request base; for `main` pushes it compares
+the pushed revision with `github.event.before`. Only a changed pinned
+NGINX/ModSecurity or Dozzle reference is scanned as a merge/deployment gate.
+Existing findings in unchanged images remain owned by the daily full-inventory
+Container Security workflow, so they do not block unrelated changes. A manual
+dispatch on `main`, or any event without a usable comparison commit, scans all
+tracked third-party images. Changes to the image policy or Trivy exceptions also
+force a full scan; tracked repositories cannot be removed silently. Each tracked
+reference must keep an allowed stable tag and an immutable SHA-256 digest.
+
+Application/runtime validation and the changed-image security gate run as
+separate jobs. The final `compose-check-and-build` aggregation job preserves the
+existing required-check name and fails if either job fails. On a `main` push,
+first-party image publication runs only after both jobs pass and is also required
+by the aggregation job before CD can start.
 
 When the daily scan finds an actionable vulnerability, it looks up newer tags
 using [`../../scripts/security/container_remediation.py`](../../scripts/security/container_remediation.py)
@@ -83,7 +100,9 @@ the security job explicitly dispatches `ci.yml` against the remediation branch.
 
 ## Failure and maintenance notes
 
-- A failing CI run blocks the corresponding CD run.
+- A newly introduced third-party image policy failure or any application/runtime
+  failure blocks the corresponding CD run; findings in unchanged third-party
+  images are tracked by the scheduled Container Security workflow.
 - Production runtime validation and rollback are implemented by
   [`../../scripts/deploy/prod_deploy.sh`](../../scripts/deploy/prod_deploy.sh).
 - Temporary vulnerability exceptions live in

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,9 @@ concurrency:
 jobs:
   deploy:
     # ci 成功之后才部署
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      ${{ github.event.workflow_run.event == 'push' &&
+          github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Deploy over SSH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,117 @@ permissions:
   packages: write
 
 jobs:
-  compose-check-and-build:
+  container-security-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout history for image comparison
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Resolve changed pinned third-party images
+        id: changed_images
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          base_sha=""
+          case "${EVENT_NAME}" in
+            pull_request)
+              base_sha="${PR_BASE_SHA}"
+              ;;
+            push)
+              base_sha="${PUSH_BEFORE_SHA}"
+              ;;
+            workflow_dispatch)
+              git fetch --no-tags origin main
+              base_sha="$(git rev-parse origin/main)"
+              if [[ "${base_sha}" == "$(git rev-parse HEAD)" ]]; then
+                base_sha=""
+              fi
+              ;;
+          esac
+
+          comparison_args=()
+          if [[ -n "${base_sha}" && ! "${base_sha}" =~ ^0+$ ]] \
+            && git cat-file -e "${base_sha}^{commit}" 2>/dev/null; then
+            base_compose="${RUNNER_TEMP}/base-compose.yml"
+            base_config="${RUNNER_TEMP}/base-container-images.json"
+            git show "${base_sha}:compose.yml" > "${base_compose}"
+            git show "${base_sha}:scripts/security/container-images.json" > "${base_config}"
+            comparison_args=(
+              --base "${base_compose}"
+              --base-config "${base_config}"
+            )
+            if ! git diff --quiet "${base_sha}" HEAD -- scripts/security/trivyignore.yaml; then
+              comparison_args+=(--force-all)
+              echo "The Trivy exception policy changed; all tracked images will be scanned."
+            fi
+            echo "Comparing pinned images in ${base_sha} with $(git rev-parse HEAD)."
+          else
+            echo "::notice title=Full third-party image scan::No usable comparison commit was available, so every tracked image will be scanned."
+          fi
+
+          images_file="${RUNNER_TEMP}/changed-third-party-images.txt"
+          python3 scripts/security/container_ci_gate.py changed \
+            --config scripts/security/container-images.json \
+            "${comparison_args[@]}" \
+            --head compose.yml > "${images_file}"
+          mapfile -t images < "${images_file}"
+          echo "count=${#images[@]}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "images<<EOF"
+            printf '%s\n' "${images[@]}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+          if (( ${#images[@]} == 0 )); then
+            {
+              echo "No pinned third-party image reference changed in this revision."
+              echo "Existing findings remain tracked by the scheduled Container Security workflow."
+            } >> "${GITHUB_STEP_SUMMARY}"
+          else
+            {
+              echo "The required security gate will scan these changed image references:"
+              printf -- '- \x60%s\x60\n' "${images[@]}"
+            } >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      # Pin the setup action to the verified immutable v0.3.1 release commit.
+      - name: Set up Trivy
+        if: steps.changed_images.outputs.count != '0'
+        uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
+        with:
+          cache: true
+          version: v0.72.0
+
+      - name: Scan changed pinned third-party images
+        if: steps.changed_images.outputs.count != '0'
+        env:
+          CHANGED_IMAGES: ${{ steps.changed_images.outputs.images }}
+          TRIVY_NO_PROGRESS: "true"
+        run: |
+          set -euo pipefail
+          scan_status=0
+          while IFS= read -r image; do
+            [[ -n "${image}" ]] || continue
+            if ! trivy image \
+              --scanners vuln \
+              --severity HIGH,CRITICAL \
+              --ignore-unfixed \
+              --ignorefile scripts/security/trivyignore.yaml \
+              --skip-version-check \
+              --exit-code 1 \
+              "${image}"; then
+              scan_status=1
+            fi
+          done <<< "${CHANGED_IMAGES}"
+          exit "${scan_status}"
+
+  application-and-runtime-checks:
     runs-on: ubuntu-latest # 使用最近的 ubuntu image
     steps:
       # 拉取代码
@@ -76,44 +186,6 @@ jobs:
           --cov-report=term-missing
           --cov-fail-under=30
 
-      - name: Resolve pinned third-party images
-        id: third_party_images
-        shell: bash
-        run: |
-          set -euo pipefail
-          mapfile -t images < <(docker compose -f compose.yml config --images)
-          for image in "${images[@]}"; do
-            case "${image}" in
-              owasp/modsecurity-crs:*) echo "nginx=${image}" >> "${GITHUB_OUTPUT}" ;;
-              amir20/dozzle:*) echo "dozzle=${image}" >> "${GITHUB_OUTPUT}" ;;
-            esac
-          done
-
-      # Pin the setup action to the verified immutable v0.3.1 release commit.
-      - name: Set up Trivy
-        uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
-        with:
-          cache: true
-          version: v0.72.0
-
-      - name: Scan pinned third-party images
-        env:
-          NGINX_IMAGE: ${{ steps.third_party_images.outputs.nginx }}
-          DOZZLE_IMAGE: ${{ steps.third_party_images.outputs.dozzle }}
-          TRIVY_NO_PROGRESS: "true"
-        run: |
-          set -euo pipefail
-          for image in "${NGINX_IMAGE}" "${DOZZLE_IMAGE}"; do
-            trivy image \
-              --scanners vuln \
-              --severity HIGH,CRITICAL \
-              --ignore-unfixed \
-              --ignorefile scripts/security/trivyignore.yaml \
-              --skip-version-check \
-              --exit-code 1 \
-              "${image}"
-          done
-
       - name: Generate temporary TLS fixture
         run: |
           mkdir -p nginx-modsecurity/ssl
@@ -149,15 +221,21 @@ jobs:
         if: always()
         run: docker compose -f compose.yml -f compose.dev.yml down --remove-orphans
 
-      # GHCR（ghcr.io）集成：
-      # - 仅在 push 事件执行（PR 只做检查，不推镜像）
-      # - 镜像命名：ghcr.io/<owner>/<repo>-<service>:<tag>
+  publish-first-party-images:
+    if: github.event_name == 'push'
+    needs:
+      - container-security-gate
+      - application-and-runtime-checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # GHCR（ghcr.io）集成：仅在 main push 的 required checks 全部通过后执行。
       - name: Set up Docker Buildx
-        if: github.event_name == 'push'
         uses: docker/setup-buildx-action@v4
 
       - name: Login to GHCR
-        if: github.event_name == 'push'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -165,7 +243,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push web-app image
-        if: github.event_name == 'push'
         uses: docker/build-push-action@v7
         with:
           context: ./web-app
@@ -175,7 +252,6 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/website-web-app:latest
 
       - name: Build and push articles-sync image
-        if: github.event_name == 'push'
         uses: docker/build-push-action@v7
         with:
           context: ./articles-sync
@@ -183,3 +259,31 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository_owner }}/website-articles-sync:${{ github.sha }}
             ghcr.io/${{ github.repository_owner }}/website-articles-sync:latest
+
+  # Preserve the existing required-check name while allowing the security and
+  # runtime jobs to finish independently and report all relevant failures.
+  compose-check-and-build:
+    if: always()
+    needs:
+      - container-security-gate
+      - application-and-runtime-checks
+      - publish-first-party-images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require successful security and runtime checks
+        env:
+          SECURITY_RESULT: ${{ needs.container-security-gate.result }}
+          APPLICATION_RESULT: ${{ needs.application-and-runtime-checks.result }}
+          PUBLISH_RESULT: ${{ needs.publish-first-party-images.result }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [[ "${SECURITY_RESULT}" != "success" \
+            || "${APPLICATION_RESULT}" != "success" \
+            || ( "${EVENT_NAME}" == "push" && "${PUBLISH_RESULT}" != "success" ) \
+            || ( "${EVENT_NAME}" != "push" && "${PUBLISH_RESULT}" != "skipped" ) ]]; then
+            echo "Container security gate: ${SECURITY_RESULT}"
+            echo "Application and runtime checks: ${APPLICATION_RESULT}"
+            echo "First-party image publication: ${PUBLISH_RESULT}"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -168,9 +168,11 @@ Host bootstrap 由 `infra/ansible/` 负责，主要用于现有 VM 的基础环�
 - 校验 Compose 配置
 - 运行 Ruff lint 与 `ruff format --check .`
 - 运行 `pytest`
-- 对固定的 Nginx/ModSecurity 与 Dozzle 镜像执行 Trivy 扫描
+- 对本次 revision 中发生变化的固定 Nginx/ModSecurity 与 Dozzle 镜像执行
+  Trivy required gate；未变化镜像的既有 finding 继续由每日全量扫描跟踪
 - 实际启动候选第三方镜像并执行 Nginx config、health 与 smoke checks
 - 在 `main` 分支 push 时构建并推送 GHCR 镜像
+- 仅由 `main` push 触发且成功的 CI run 启动 CD；手动 CI 不会部署
 
 ### CD
 

--- a/scripts/security/README.md
+++ b/scripts/security/README.md
@@ -4,6 +4,16 @@
 Container Security workflow to find newer Docker Hub images and replace one
 exact pinned `tag@digest` reference in `compose.yml`.
 
+`container_ci_gate.py` is the required CI gate helper. It reads the tracked
+repositories from `container-images.json`, compares their exact pinned image
+references between base and head Compose files, and prints only changed head
+references. Every tracked reference must use an allowed stable tag and a full
+immutable SHA-256 digest; missing, duplicate, malformed, or silently removed
+tracked images fail closed. Changes to `container-images.json` or
+`trivyignore.yaml` force a full tracked-image scan. CI scans the selected
+references with the same fixable HIGH/CRITICAL policy while the daily Container
+Security workflow retains responsibility for full-inventory scans.
+
 The helper does not decide whether an update is safe. The workflow first scans
 the currently pinned images, calls this helper to discover newer stable tags,
 then scans each candidate with the same Trivy policy used by CI. A candidate is
@@ -42,6 +52,11 @@ python3 scripts/security/container_remediation.py replace \
   --file compose.yml \
   --current 'amir20/dozzle:v10.6.14@sha256:...' \
   --candidate 'amir20/dozzle:v10.7.1@sha256:...'
+
+python3 scripts/security/container_ci_gate.py changed \
+  --config scripts/security/container-images.json \
+  --base /tmp/base-compose.yml \
+  --head compose.yml
 
 python3 -m unittest discover -s scripts/security/tests -p 'test_*.py' -v
 ```

--- a/scripts/security/container_ci_gate.py
+++ b/scripts/security/container_ci_gate.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Select pinned third-party images changed by the current revision."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+from container_remediation import RemediationError, load_policy, parse_image_reference
+
+
+IMAGE_PATTERN = re.compile(
+    r"^\s*image:\s*(?:\"(?P<double>[^\"]+)\"|'(?P<single>[^']+)'|(?P<plain>[^\s#]+))"
+)
+
+
+class GateError(RuntimeError):
+    """Raised when the comparison inputs cannot produce a safe gate decision."""
+
+
+def image_repository(reference: str) -> str:
+    """Return the repository portion of a tag-and/or-digest image reference."""
+    without_digest = reference.partition("@")[0]
+    last_slash = without_digest.rfind("/")
+    last_colon = without_digest.rfind(":")
+    if last_colon > last_slash:
+        repository = without_digest[:last_colon]
+    else:
+        repository = without_digest
+    if not repository:
+        raise GateError(f"Invalid image reference: {reference!r}")
+    return repository
+
+
+def load_tracked_policies(config_path: Path) -> dict[str, dict[str, str]]:
+    try:
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise GateError(f"Unable to read {config_path}: {error}") from error
+
+    if not isinstance(config, dict):
+        raise GateError(f"{config_path} must contain a JSON object")
+    images = config.get("images")
+    if not isinstance(images, dict) or not images:
+        raise GateError(f"{config_path} must contain a non-empty 'images' object")
+    if not all(isinstance(repository, str) and repository for repository in images):
+        raise GateError(f"{config_path} contains an invalid image repository")
+    try:
+        return {
+            repository: load_policy(config_path, repository) for repository in images
+        }
+    except RemediationError as error:
+        raise GateError(str(error)) from error
+
+
+def read_tracked_images(
+    compose_path: Path, policies: dict[str, dict[str, str]]
+) -> dict[str, str]:
+    try:
+        content = compose_path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise GateError(f"Unable to read {compose_path}: {error}") from error
+
+    tracked = set(policies)
+    resolved: dict[str, str] = {}
+    for line in content.splitlines():
+        match = IMAGE_PATTERN.match(line)
+        if match is None:
+            continue
+        reference = next(
+            value for value in match.groupdict().values() if value is not None
+        )
+        repository = image_repository(reference)
+        if repository not in tracked:
+            continue
+        try:
+            parsed = parse_image_reference(reference)
+        except RemediationError as error:
+            raise GateError(
+                f"Invalid tracked image in {compose_path}: {error}"
+            ) from error
+        if parsed.digest is None:
+            raise GateError(
+                f"Tracked image {reference!r} in {compose_path} must pin a sha256 digest"
+            )
+        if re.fullmatch(policies[repository]["tag_regex"], parsed.tag) is None:
+            raise GateError(
+                f"Tracked image tag {parsed.tag!r} in {compose_path} does not match "
+                f"the configured policy for {repository!r}"
+            )
+        if repository in resolved:
+            raise GateError(
+                f"Expected one {repository!r} image in {compose_path}, found more than one"
+            )
+        resolved[repository] = reference
+
+    missing = [repository for repository in policies if repository not in resolved]
+    if missing:
+        raise GateError(
+            f"Missing tracked images in {compose_path}: {', '.join(missing)}"
+        )
+    return resolved
+
+
+def select_changed_images(
+    base_images: dict[str, str] | None,
+    head_images: dict[str, str],
+    repositories: list[str],
+) -> list[str]:
+    if base_images is None:
+        return [head_images[repository] for repository in repositories]
+    return [
+        head_images[repository]
+        for repository in repositories
+        if head_images[repository] != base_images.get(repository)
+    ]
+
+
+def policies_require_full_scan(
+    base_policies: dict[str, dict[str, str]],
+    head_policies: dict[str, dict[str, str]],
+) -> bool:
+    """Reject silent repository removal and detect policy changes."""
+    removed = [
+        repository for repository in base_policies if repository not in head_policies
+    ]
+    if removed:
+        raise GateError(
+            "Tracked image repositories cannot be removed silently: "
+            + ", ".join(removed)
+        )
+    return base_policies != head_policies
+
+
+def changed_command(args: argparse.Namespace) -> None:
+    head_policies = load_tracked_policies(args.config)
+    head_images = read_tracked_images(args.head, head_policies)
+    base_images = None
+
+    if args.base_config is not None and args.base is None:
+        raise GateError("--base-config requires --base")
+    if args.base is not None:
+        base_policies = (
+            load_tracked_policies(args.base_config)
+            if args.base_config is not None
+            else head_policies
+        )
+        policy_changed = policies_require_full_scan(base_policies, head_policies)
+        if not args.force_all and not policy_changed:
+            base_images = read_tracked_images(args.base, base_policies)
+
+    for image in select_changed_images(base_images, head_images, list(head_policies)):
+        print(image)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    changed = subparsers.add_parser(
+        "changed", help="print changed head image references, one per line"
+    )
+    changed.add_argument("--config", type=Path, required=True)
+    changed.add_argument("--base", type=Path)
+    changed.add_argument("--base-config", type=Path)
+    changed.add_argument("--force-all", action="store_true")
+    changed.add_argument("--head", type=Path, required=True)
+    changed.set_defaults(handler=changed_command)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        args.handler(args)
+    except GateError as error:
+        print(f"container CI gate error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/security/tests/test_container_remediation.py
+++ b/scripts/security/tests/test_container_remediation.py
@@ -16,13 +16,18 @@ from container_remediation import (  # noqa: E402
     replace_image_reference,
     select_candidates,
 )
+from container_ci_gate import (  # noqa: E402
+    GateError,
+    image_repository,
+    policies_require_full_scan,
+    read_tracked_images,
+    select_changed_images,
+)
 
 
 class ContainerRemediationTests(unittest.TestCase):
     def test_parse_pinned_reference(self):
-        reference = parse_image_reference(
-            "amir20/dozzle:v10.6.14@sha256:" + "a" * 64
-        )
+        reference = parse_image_reference("amir20/dozzle:v10.6.14@sha256:" + "a" * 64)
 
         self.assertEqual(reference.repository, "amir20/dozzle")
         self.assertEqual(reference.tag, "v10.6.14")
@@ -51,7 +56,9 @@ class ContainerRemediationTests(unittest.TestCase):
 
         candidates = select_candidates(image, policy, records, max_candidates=10)
 
-        self.assertEqual([candidate["tag"] for candidate in candidates], ["v10.7.1", "v10.6.15"])
+        self.assertEqual(
+            [candidate["tag"] for candidate in candidates], ["v10.7.1", "v10.6.15"]
+        )
         self.assertEqual(
             candidates[0]["image"],
             "amir20/dozzle:v10.7.1@sha256:" + "3" * 64,
@@ -80,14 +87,19 @@ class ContainerRemediationTests(unittest.TestCase):
 
         candidates = select_candidates(image, policy, records, max_candidates=10)
 
-        self.assertEqual([candidate["tag"] for candidate in candidates], ["4-nginx-alpine-202608050608"])
+        self.assertEqual(
+            [candidate["tag"] for candidate in candidates],
+            ["4-nginx-alpine-202608050608"],
+        )
 
     def test_replace_requires_exactly_one_matching_reference(self):
         current = "amir20/dozzle:v10.6.14@sha256:" + "1" * 64
         candidate = "amir20/dozzle:v10.7.1@sha256:" + "2" * 64
         with tempfile.TemporaryDirectory() as directory:
             compose_file = Path(directory) / "compose.yml"
-            compose_file.write_text(f"services:\n  dozzle:\n    image: {current}\n", encoding="utf-8")
+            compose_file.write_text(
+                f"services:\n  dozzle:\n    image: {current}\n", encoding="utf-8"
+            )
 
             replace_image_reference(compose_file, current, candidate)
 
@@ -114,6 +126,212 @@ class ContainerRemediationTests(unittest.TestCase):
 
             with self.assertRaises(RemediationError):
                 load_policy(config_file, "amir20/dozzle")
+
+
+class ContainerCiGateTests(unittest.TestCase):
+    policies = {
+        "amir20/dozzle": {
+            "tag_regex": r"^v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)$",
+            "version_scheme": "semver",
+        },
+        "owasp/modsecurity-crs": {
+            "tag_regex": r"^4-nginx-alpine-(?P<version>[0-9]{12})$",
+            "version_scheme": "numeric",
+        },
+    }
+    repositories = list(policies)
+
+    @staticmethod
+    def digest(character):
+        return "sha256:" + character * 64
+
+    def test_extracts_repository_from_tag_and_digest(self):
+        reference = (
+            "owasp/modsecurity-crs:4-nginx-alpine-202608131208@sha256:" + "a" * 64
+        )
+
+        self.assertEqual(image_repository(reference), "owasp/modsecurity-crs")
+
+    def test_reads_tracked_images_and_ignores_first_party_images(self):
+        dozzle = f"amir20/dozzle:v10.7.2@{self.digest('1')}"
+        modsecurity = (
+            "owasp/modsecurity-crs:4-nginx-alpine-202608131208@" + self.digest("2")
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            compose_file = Path(directory) / "compose.yml"
+            compose_file.write_text(
+                f"""services:
+  web:
+    image: ghcr.io/example/web:latest
+  dozzle:
+    image: {dozzle}
+  nginx:
+    image: \"{modsecurity}\"
+""",
+                encoding="utf-8",
+            )
+
+            images = read_tracked_images(compose_file, self.policies)
+
+        self.assertEqual(
+            images,
+            {
+                "amir20/dozzle": dozzle,
+                "owasp/modsecurity-crs": modsecurity,
+            },
+        )
+
+    def test_selects_only_changed_head_images(self):
+        base = {
+            "amir20/dozzle": "amir20/dozzle:v10.7.2@sha256:111",
+            "owasp/modsecurity-crs": "owasp/modsecurity-crs:old@sha256:222",
+        }
+        head = {
+            "amir20/dozzle": "amir20/dozzle:v10.7.4@sha256:333",
+            "owasp/modsecurity-crs": "owasp/modsecurity-crs:old@sha256:222",
+        }
+
+        changed = select_changed_images(base, head, self.repositories)
+
+        self.assertEqual(changed, ["amir20/dozzle:v10.7.4@sha256:333"])
+
+    def test_same_tag_digest_change_is_selected(self):
+        base = {
+            "amir20/dozzle": "amir20/dozzle:v10.7.4@sha256:111",
+            "owasp/modsecurity-crs": "owasp/modsecurity-crs:stable@sha256:222",
+        }
+        head = {
+            "amir20/dozzle": "amir20/dozzle:v10.7.4@sha256:333",
+            "owasp/modsecurity-crs": "owasp/modsecurity-crs:stable@sha256:222",
+        }
+
+        changed = select_changed_images(base, head, self.repositories)
+
+        self.assertEqual(changed, ["amir20/dozzle:v10.7.4@sha256:333"])
+
+    def test_without_base_selects_every_tracked_image(self):
+        head = {
+            "amir20/dozzle": "amir20/dozzle:v10.7.4@sha256:333",
+            "owasp/modsecurity-crs": "owasp/modsecurity-crs:new@sha256:444",
+        }
+
+        changed = select_changed_images(None, head, self.repositories)
+
+        self.assertEqual(
+            changed, [head[repository] for repository in self.repositories]
+        )
+
+    def test_missing_tracked_image_fails_closed(self):
+        dozzle = f"amir20/dozzle:v10.7.2@{self.digest('1')}"
+        with tempfile.TemporaryDirectory() as directory:
+            compose_file = Path(directory) / "compose.yml"
+            compose_file.write_text(
+                f"services:\n  dozzle:\n    image: {dozzle}\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(GateError):
+                read_tracked_images(compose_file, self.policies)
+
+    def test_duplicate_tracked_image_fails_closed(self):
+        dozzle = f"amir20/dozzle:v10.7.2@{self.digest('1')}"
+        modsecurity = (
+            "owasp/modsecurity-crs:4-nginx-alpine-202608131208@" + self.digest("2")
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            compose_file = Path(directory) / "compose.yml"
+            compose_file.write_text(
+                f"""services:
+  dozzle:
+    image: {dozzle}
+  dozzle-copy:
+    image: {dozzle}
+  nginx:
+    image: {modsecurity}
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(GateError):
+                read_tracked_images(compose_file, self.policies)
+
+    def test_unpinned_tracked_image_fails_closed(self):
+        modsecurity = (
+            "owasp/modsecurity-crs:4-nginx-alpine-202608131208@" + self.digest("2")
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            compose_file = Path(directory) / "compose.yml"
+            compose_file.write_text(
+                f"""services:
+  dozzle:
+    image: amir20/dozzle:v10.7.2
+  nginx:
+    image: {modsecurity}
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(GateError):
+                read_tracked_images(compose_file, self.policies)
+
+    def test_unapproved_tag_fails_closed(self):
+        dozzle = f"amir20/dozzle:latest@{self.digest('1')}"
+        modsecurity = (
+            "owasp/modsecurity-crs:4-nginx-alpine-202608131208@" + self.digest("2")
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            compose_file = Path(directory) / "compose.yml"
+            compose_file.write_text(
+                f"""services:
+  dozzle:
+    image: {dozzle}
+  nginx:
+    image: {modsecurity}
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(GateError):
+                read_tracked_images(compose_file, self.policies)
+
+    def test_invalid_digest_fails_closed(self):
+        dozzle = "amir20/dozzle:v10.7.2@sha256:123"
+        modsecurity = (
+            "owasp/modsecurity-crs:4-nginx-alpine-202608131208@" + self.digest("2")
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            compose_file = Path(directory) / "compose.yml"
+            compose_file.write_text(
+                f"""services:
+  dozzle:
+    image: {dozzle}
+  nginx:
+    image: {modsecurity}
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(GateError):
+                read_tracked_images(compose_file, self.policies)
+
+    def test_policy_change_requires_full_scan(self):
+        base = self.policies
+        head = {
+            **self.policies,
+            "amir20/dozzle": {
+                **self.policies["amir20/dozzle"],
+                "version_scheme": "numeric",
+            },
+        }
+
+        self.assertTrue(policies_require_full_scan(base, head))
+        self.assertFalse(policies_require_full_scan(base, base))
+
+    def test_policy_repository_removal_fails_closed(self):
+        head = {"amir20/dozzle": self.policies["amir20/dozzle"]}
+
+        with self.assertRaises(GateError):
+            policies_require_full_scan(self.policies, head)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- make the required Trivy gate revision-aware so unchanged third-party image findings do not block unrelated PRs
- fail closed on malformed/mutable pins, policy changes, missing images, and tracked repository removal
- run security and runtime validation independently while preserving the existing compose-check-and-build required check
- publish first-party images only after both gates pass and restrict CD to successful push-triggered CI runs

## Verification

- 18 container security unit tests
- Ruff format/check and Python compileall
- actionlint v1.7.12 across all workflows
- ShellCheck for deployment and article-sync scripts
- production and development Compose config validation
- real revision simulations: unchanged refs select none; PR #48 selects only Dozzle; missing baseline selects all tracked images